### PR TITLE
Sanitize user output

### DIFF
--- a/src/controllers/authentication.ts
+++ b/src/controllers/authentication.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import { getUserByEmail, createUser } from "../db/users";
-import { random, authentication } from "../helpers";
+import { random, authentication, toSafeUser } from "../helpers";
 
 export const login = async (req: express.Request, res: express.Response) => {
     try {
@@ -29,7 +29,7 @@ export const login = async (req: express.Request, res: express.Response) => {
         await user.save();//Burada save yapmak ne kadar mantıklı?
 
         res.cookie("NODE-TS-AUTH", user.authentication.sessionToken, { domain: "localhost", path: "/" });
-        return res.status(200).json(user).end();
+        return res.status(200).json(toSafeUser(user)).end();
     } catch (error) {
         console.log(error);
         return res.sendStatus(400);
@@ -58,7 +58,7 @@ export const register = async (req: express.Request, res: express.Response) => {
                 password: authentication(salt, password)
             }
         });
-        return res.status(200).json(user).end();//burada response'da tüm user'a ait bilgileri göndermemek lazım.(Örneğin: password, salt)
+        return res.status(200).json(toSafeUser(user)).end();
     } catch (error) {
         console.log(error);
         return res.sendStatus(400);

--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -1,10 +1,12 @@
 import { deleteUserById, getUserById, getUsers, updateUserById } from "../db/users";
 import express from "express";
+import { toSafeUser } from "../helpers";
 
 export const getAllUsers = async (req: express.Request, res: express.Response) => {
     try {
         const users = await getUsers();
-        return res.status(200).json(users);
+        const safeUsers = users.map((user) => toSafeUser(user));
+        return res.status(200).json(safeUsers);
     } catch (error) {
         console.log(error);
         return res.sendStatus(400);
@@ -15,7 +17,10 @@ export const deleteUser = async (req: express.Request, res: express.Response) =>
     try {
         const { id } = req.params;
         const deletedUser = await deleteUserById(id);
-        return res.json(deletedUser);
+        if (!deletedUser) {
+            return res.sendStatus(400);
+        }
+        return res.json(toSafeUser(deletedUser));
     } catch (error) {
         console.log(error);
         return res.sendStatus(400);
@@ -32,8 +37,8 @@ export const updateUser = async (req: express.Request, res: express.Response) =>
             return res.sendStatus(400);
         }
 
-        const updatedUser = await updateUserById(id, username);
-        return res.json(updatedUser).end();
+        const updatedUser = await updateUserById(id, { username });
+        return res.json(toSafeUser(updatedUser)).end();
     } catch (error) {
         console.log(error);
         return res.sendStatus(400);

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -6,7 +6,21 @@ const UserSchema = new mongoose.Schema({
     authentication: {
         password: { type: String, required: true, select: false },
         salt: { type: String, select: false },
-        sessionToken: { type: String, select: false },//Db'ye yazmıyoruz ama session'larda kullanıyoruz.
+        sessionToken: { type: String, select: false }, // Db'ye yazmıyoruz ama session'larda kullanıyoruz.
+    },
+});
+
+UserSchema.set('toJSON', {
+    transform: (_doc, ret) => {
+        if (ret.authentication) {
+            delete ret.authentication.password;
+            delete ret.authentication.salt;
+            delete ret.authentication.sessionToken;
+            if (!Object.keys(ret.authentication).length) {
+                delete ret.authentication;
+            }
+        }
+        return ret;
     },
 });
 

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -6,3 +6,9 @@ export const random = () => crypto.randomBytes(128).toString("base64");
 export const authentication = (salt: string, password: string) => {
     return crypto.createHmac("sha256", [salt, password].join("/")).update(SECRET).digest("hex");
 };
+
+export const toSafeUser = (user: { _id: any; email: string; username: string }) => ({
+    _id: user._id,
+    email: user.email,
+    username: user.username,
+});


### PR DESCRIPTION
## Summary
- hide sensitive fields in controllers
- add Mongoose toJSON transform to strip auth data
- ensure updateUser uses object for updates
- centralize user sanitization in helper

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851ce9721e48333bb359630146c0e19