### PR TITLE
Improve auth cookie security

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,23 @@ Create a `.env` file in development with these values and run `npm start` to loa
 MONGO_URL=mongodb://localhost/mydb
 SECRET=yourSecretKey
 ```
+
+To enable HTTPS directly in Node.js, also provide your certificate and key:
+
+```bash
+HTTPS_KEY=./certs/key.pem
+HTTPS_CERT=./certs/cert.pem
+```
+Optionally set `HTTPS_PORT` to override the default `8443`.
+
+## HTTP and HTTPS
+
+The server is configured to work behind a proxy and will set secure cookies only
+when accessed over HTTPS. When running behind a reverse proxy, ensure that the
+`X-Forwarded-Proto` header is forwarded so the application can detect HTTPS
+connections.
+
+Alternatively you can run HTTPS directly in Node.js by providing `HTTPS_KEY` and
+`HTTPS_CERT` as shown above. When both variables are set the server will listen
+on the configured `HTTPS_PORT` (default `8443`) in addition to the regular HTTP
+port.

--- a/src/controllers/authentication.ts
+++ b/src/controllers/authentication.ts
@@ -26,9 +26,15 @@ export const login = async (req: express.Request, res: express.Response) => {
         const salt = random();
         user.authentication.sessionToken = authentication(salt, user._id.toString());
 
-        await user.save();//Burada save yapmak ne kadar mantıklı?
+        await user.save();
 
-        res.cookie("NODE-TS-AUTH", user.authentication.sessionToken, { domain: "localhost", path: "/" });
+        const isSecure = req.secure || req.headers["x-forwarded-proto"] === "https";
+        res.cookie("NODE-TS-AUTH", user.authentication.sessionToken, {
+            domain: "localhost",
+            path: "/",
+            httpOnly: true,
+            secure: isSecure,
+        });
         return res.status(200).json(toSafeUser(user)).end();
     } catch (error) {
         console.log(error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import express from "express";
 import http from "http";
+import https from "https";
+import fs from "fs";
 import bodyParser from "body-parser";
 import cookieParser from "cookie-parser";
 import compression from "compression";
@@ -11,6 +13,7 @@ import router from './router';
 dotenv.config();
 
 const app = express();
+app.set('trust proxy', true);
 
 app.use(cors({
     credentials: true,
@@ -20,11 +23,24 @@ app.use(compression());
 app.use(cookieParser());
 app.use(bodyParser.json());
 
-const server = http.createServer(app);
-
-server.listen(8080, () => {
-    console.log("Server is running on port http://localhost:8080");
+const HTTP_PORT = parseInt(process.env.PORT || "8080", 10);
+http.createServer(app).listen(HTTP_PORT, () => {
+    console.log(`HTTP server is running on http://localhost:${HTTP_PORT}`);
 });
+
+const HTTPS_KEY = process.env.HTTPS_KEY;
+const HTTPS_CERT = process.env.HTTPS_CERT;
+const HTTPS_PORT = parseInt(process.env.HTTPS_PORT || "8443", 10);
+
+if (HTTPS_KEY && HTTPS_CERT) {
+    const httpsOptions = {
+        key: fs.readFileSync(HTTPS_KEY),
+        cert: fs.readFileSync(HTTPS_CERT),
+    };
+    https.createServer(httpsOptions, app).listen(HTTPS_PORT, () => {
+        console.log(`HTTPS server is running on https://localhost:${HTTPS_PORT}`);
+    });
+}
 
 const MONGO_URL = process.env.MONGO_URL || '';
 


### PR DESCRIPTION
## Summary
- secure login cookie with `httpOnly` and conditional `secure` flags
- trust proxy headers for HTTPS detection
- add optional HTTPS server support
- document HTTPS usage with environment variables
- remove outdated inline comment

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852560c6f68833381b1e5bd37c9bceb